### PR TITLE
correct typo in iOS ModelDataHandler.swift

### DIFF
--- a/ios/Classes/ModelDataHandler.swift
+++ b/ios/Classes/ModelDataHandler.swift
@@ -116,7 +116,7 @@ class ModelDataHandler {
                         "frame" : frames[idx],
                         "onset" : onsets[idx],
                         "offset" : offsets[idx],
-                        "velocitiy" : velocities[idx]
+                        "velocity" : velocities[idx]
                     ]
                     result.append(dic)
                 }


### PR DESCRIPTION
The dart file contains "`getNotesDetail` returns the recognized notes and displays the `[key, frame, onset, offset, velocity]` details." but in ModelDataHandler for iOS it is "velocitiy" instead of velocity.